### PR TITLE
Fix undefined vim warning in lua

### DIFF
--- a/files/.config/nvim/lua/plugins/completion.lua
+++ b/files/.config/nvim/lua/plugins/completion.lua
@@ -88,10 +88,12 @@ return {
       local lspconfig = require('lspconfig')
 
       lspconfig.lua_ls.setup({
-        Lua = {
-          diagnostics = {
-            globals = {
-              'vim',
+        settings = {
+          Lua = {
+            diagnostics = {
+              globals = {
+                'vim',
+              },
             },
           },
         },


### PR DESCRIPTION
# WHAT

- Suppress `Undefined global 'vim'` warning.

# WHY

- we can ignore that warning because the 'vim' is defined in vim configs written in Lua.
